### PR TITLE
Add Arduino Uno R4 WiFi / Minima (RA4M1) support

### DIFF
--- a/HARDWARE_TESTING.md
+++ b/HARDWARE_TESTING.md
@@ -1,0 +1,252 @@
+# Hardware testing guide — Uno R4 WiFi on the Pololu Zumo Shield v1.3
+
+This document walks through bringing up the `feature/uno-r4-wifi-timers`
+branch on a real Zumo robot with an Arduino Uno R4 WiFi plugged into the
+shield. Work through the sections in order — each test isolates one
+subsystem so that if something fails you know exactly which subsystem
+owns it.
+
+## 0. What you need
+
+**Hardware**
+- Pololu Zumo Shield v1.3 (assembled on a Zumo chassis with 75:1 HP motors
+  and 4× AA batteries, or equivalent).
+- Arduino Uno R4 WiFi (or R4 Minima — same MCU).
+- USB-C cable for programming.
+- Optional: Pololu Zumo Reflectance Sensor Array, if you plan to test
+  the line-following subsystem.
+
+**Software**
+- Arduino IDE 2.x (or Arduino CLI ≥ 0.35).
+- **Arduino Renesas Uno Boards** package installed (Tools → Board →
+  Boards Manager → search "Uno R4" → install).
+- This fork cloned locally:
+  ```
+  git clone https://github.com/shashankbl/zumo-shield-arduino-rev4wifi-library.git
+  cd zumo-shield-arduino-rev4wifi-library
+  git checkout feature/uno-r4-wifi-timers
+  ```
+
+**Safety checks before powering on**
+- Battery polarity in the Zumo battery holder is correct.
+- The Arduino is seated fully on the shield headers with no bent pins.
+- Nothing is touching the motor terminals or exposed leads on the
+  underside of the shield.
+- Put the Zumo on a book or small box so the wheels spin free during
+  early motor tests — the first motor sketch will move the robot.
+
+## 1. Install the library in the Arduino IDE
+
+Arduino needs to see this library to compile the examples that
+`#include <ZumoShield.h>`.
+
+1. Close the Arduino IDE if it's open.
+2. Symlink (or copy) the cloned repo into your Arduino libraries folder:
+   ```
+   ln -s "$(pwd)" ~/Arduino/libraries/ZumoShield
+   ```
+   (On Windows, copy the folder to `Documents\Arduino\libraries\ZumoShield`.
+   On macOS, it's `~/Documents/Arduino/libraries/ZumoShield`.)
+3. Re-open the Arduino IDE. Confirm it loaded:
+   `File → Examples → ZumoShield` should now list
+   `ZumoMotorExample`, `ZumoBuzzerExample`, etc.
+
+**If the examples don't appear:** check that the library folder is named
+exactly `ZumoShield` (not `zumo-shield-arduino-rev4wifi-library`) and
+that `library.properties` is at its top level.
+
+## 2. Select the board
+
+1. Plug the Uno R4 WiFi into USB.
+2. `Tools → Board → Arduino Renesas Uno Boards → Arduino Uno R4 WiFi`.
+3. `Tools → Port → <your USB port>` (typically `/dev/ttyACM0` on Linux,
+   `COMn` on Windows).
+4. Compile a trivial sketch first (e.g. `File → Examples → 01.Basics →
+   Blink`) and upload it. **Don't proceed until this baseline works** —
+   if it fails, the toolchain is broken and Zumo-specific tests will
+   just add noise.
+
+## 3. Test motors in isolation — `ZumoMotorExample`
+
+This is the most important first test because it exercises the new
+`PwmOut`-based 20 kHz PWM backend on pins 9 and 10.
+
+1. **Prop the wheels off the ground.**
+2. `File → Examples → ZumoShield → ZumoMotorExample`.
+3. Verify the sketch compiles. If you see any error mentioning
+   `TCCR1A`, `OCR1A`, `OCR1B`, or `ICR1`, you're compiling the AVR path
+   by mistake — recheck the board selection.
+4. Upload. Open the Serial Monitor at 9600 baud.
+
+**Expected behaviour**
+- User-button press (Zumo pushbutton, D12) starts a demo: forward, turn,
+  backward, reverse-turn — each for a short interval.
+- Both wheels spin smoothly at matched speeds.
+- **No audible whine from the motors.** If you hear a clear ~500 Hz tone
+  when the motors run, the `PwmOut` 20 kHz path didn't activate and the
+  code fell through to `analogWrite()`'s default — check that
+  `ARDUINO_UNOR4_WIFI` is being defined during the build.
+
+**Direction check**
+- `setSpeeds(200, 200)` → forward (both wheels spin "outward"
+  at the bottom).
+- `setSpeeds(-200, -200)` → backward.
+- If one wheel goes the wrong way, use `flipLeftMotor(true)` or
+  `flipRightMotor(true)` in `setup()` — the motor wiring on some Zumo
+  kits is mirrored.
+
+## 4. Test the buzzer — `ZumoBuzzerExample`
+
+Exercises the `FspTimer` + `tone()` backend.
+
+1. `File → Examples → ZumoShield → ZumoBuzzerExample`.
+2. Upload. You should hear a short beep or melody.
+
+**Expected behaviour**
+- Pressing the pushbutton triggers a melody on D3 (buzzer pin).
+- Notes advance on their own while `loop()` does other things —
+  this proves the `FspTimer` interrupt path is working
+  (`PLAY_AUTOMATIC` mode).
+
+**Known differences vs the Uno R3** (documented in [README.md](README.md)
+under "Uno R4 support"):
+- Volume is fixed at ~50 % duty — passing `volume = 5` vs `volume = 15`
+  produces the same loudness on R4. This is expected, not a bug.
+- Frequencies below ~100 Hz are rounded to whole Hz; a 41.2 Hz note
+  plays at 41 Hz.
+
+**If nothing plays at all:**
+- Check that you hear the buzzer click when the board resets (it shouldn't,
+  but any pop indicates the pin is wired).
+- Verify the `FspTimer` library shipped with the Renesas core — it's in
+  `~/.arduino15/packages/arduino/hardware/renesas_uno/<version>/libraries/FspTimer`.
+  If missing, reinstall the board package.
+- Confirm the compiler actually picked the R4 branch by adding a
+  temporary `#warning "R4 path active"` at the top of the R4 block in
+  [PololuBuzzer.cpp:14](PololuBuzzer.cpp#L14) and looking for it in the
+  compile log.
+
+## 5. Test the pushbutton — `PushbuttonExample`
+
+Sanity check for `digitalRead()` on D12 and the internal pull-up on R4.
+The stock example uses only the onboard LED for feedback — no serial
+output.
+
+1. Upload `PushbuttonExample`.
+2. Press and release the Zumo user button (D12). The onboard LED (D13)
+   should blink once per full press-and-release cycle.
+3. The sketch exercises three detection paths in sequence — `isPressed()`
+   with manual debounce, `waitForButton()`, and `getSingleDebouncedRelease()`.
+   Press the button three times to cycle through all three; each press
+   should produce an LED blink before the sketch advances to the next
+   method.
+
+This should work with zero code changes — the Pushbutton class uses only
+standard Arduino APIs.
+
+**Want serial feedback too?** Add these four edits to
+[PushbuttonExample.ino](examples/PushbuttonExample/PushbuttonExample.ino)
+(only needed if the LED-only output isn't enough for your bring-up):
+
+```cpp
+void setup()
+{
+  Serial.begin(9600);            // add this
+  pinMode(LED_PIN, OUTPUT);
+}
+```
+
+Then add a `Serial.println("pressed (methodN)");` after each
+`digitalWrite(LED_PIN, HIGH)` line. Open the Serial Monitor at
+**9600 baud, line ending: "Newline"** and you'll see one line per
+press.
+
+## 6. Test the inertial sensors — `InertialSensors`
+
+Exercises I2C (`Wire`) and the `ZumoIMU` class.
+
+1. Upload `InertialSensors`.
+2. Open Serial Monitor at 9600 baud.
+3. Expect a continuous stream of accelerometer, gyro, and magnetometer
+   readings.
+
+**Expected behaviour**
+- With the Zumo stationary on a flat surface:
+  - Accelerometer Z ≈ 1 g (~16000 on an LSM6DS33 in the default range),
+    X and Y near zero.
+  - Gyro values fluctuate around zero (a few hundred counts of noise is
+    normal).
+- Rotate the robot by hand — gyro values on the rotated axis should
+  spike, then return to noise when stationary again.
+
+**If values are all zero or all -1:** the I2C bus isn't talking. On
+R4 WiFi, SDA/SCL are at the same physical header positions as the R3,
+so wiring isn't the issue — check `Tools → Board` is set to R4 WiFi
+and not R4 Minima if you have a WiFi board (the pin mapping differs on
+the secondary headers but the I2C pins are identical for the Zumo).
+
+## 7. Test the reflectance sensor array — `LineSensorTest`
+
+*(Skip this section if you don't have the Zumo Reflectance Sensor Array
+attached.)*
+
+1. Upload `LineSensorTest`.
+2. Serial Monitor at 9600 baud.
+3. Hold the Zumo over a white surface → all 6 sensor readings should be
+   low (reflective → short pulse).
+4. Slide a strip of black electrical tape under the sensors → readings
+   over the tape should spike to ~2000 (the `timeout` default).
+
+No code change was needed for the sensor array on R4, but this confirms
+that the hardcoded pin array `{4, A3, 11, A0, A2, 5}` in
+[ZumoReflectanceSensorArray.h:155](ZumoReflectanceSensorArray.h#L155)
+maps correctly to the R4 WiFi's header pins.
+
+## 8. Full-stack integration test — `LineFollower` or `SumoCollisionDetect`
+
+Pick one to prove motors + buzzer + sensors all work together.
+
+- **LineFollower**: needs a track (black tape on white). Exercises
+  motors, reflectance array, and the calibration flow.
+- **SumoCollisionDetect**: uses the IMU to detect impacts. Exercises
+  motors + IMU + buzzer.
+
+Upload, place the robot on the required surface, press the user button,
+and confirm end-to-end behaviour matches what the example's README or
+comment header describes.
+
+## 9. Regression test — verify you didn't break the AVR path
+
+If you also have an Uno R3 lying around:
+
+1. Swap the R4 WiFi off the shield and install the R3 (power off first).
+2. `Tools → Board → Arduino AVR Boards → Arduino Uno`.
+3. Recompile and re-upload each example from sections 3–8.
+4. Everything should still work exactly as it did on upstream 2.1.0.
+
+The AVR code paths in this fork are gated by `__AVR__` / `__AVR_ATmega328P__`
+/ `__AVR_ATmega32U4__` and are byte-identical to upstream. If an AVR
+regression appears, it's a bug in this fork and should be filed as
+an issue.
+
+## 10. Reporting results
+
+When you report test results (or file a bug), please include:
+
+- Arduino IDE version and Renesas Uno Boards package version.
+- Output of `git -C <repo> rev-parse HEAD` so we know the exact commit.
+- Which example(s) failed, with the full serial output.
+- Expected vs observed behaviour.
+- Whether the same example works on an Uno R3 (to rule out a shield
+  wiring issue vs a port regression).
+
+## Quick reference: what each subsystem relies on
+
+| Subsystem | R4 backend | Files touched by the port |
+| --- | --- | --- |
+| Motor PWM (D9, D10) | `PwmOut` @ 20 kHz | [ZumoMotors.cpp](ZumoMotors.cpp) |
+| Motor direction (D7, D8) | `digitalWrite` | unchanged |
+| Buzzer (D3) | `tone()` + `FspTimer` @ 1 kHz | [PololuBuzzer.cpp](PololuBuzzer.cpp), [PololuBuzzer.h](PololuBuzzer.h) |
+| Pushbutton (D12) | `digitalRead` w/ pull-up | unchanged |
+| Reflectance sensors (4, A3, 11, A0, A2, 5) | `micros()` pulse timing | unchanged |
+| IMU (I2C on SDA/SCL) | `Wire` | unchanged |

--- a/HARDWARE_TESTING.md
+++ b/HARDWARE_TESTING.md
@@ -97,16 +97,21 @@ This is the most important first test because it exercises the new
 
 ## 4. Test the buzzer — `ZumoBuzzerExample`
 
-Exercises the `FspTimer` + `tone()` backend.
+Exercises the R4 backend: `tone(pin, freq, duration)` for the audio
+plus `millis()` polling inside `isPlaying()` / `playCheck()` for
+note-sequence advancement.
 
 1. `File → Examples → ZumoShield → ZumoBuzzerExample`.
-2. Upload. You should hear a short beep or melody.
+2. Upload. The Super Mario theme melody should play through on its own.
+3. Press the Zumo pushbutton (D12) to silence / restart the melody.
 
 **Expected behaviour**
-- Pressing the pushbutton triggers a melody on D3 (buzzer pin).
-- Notes advance on their own while `loop()` does other things —
-  this proves the `FspTimer` interrupt path is working
-  (`PLAY_AUTOMATIC` mode).
+- Melody plays note-by-note at the programmed rhythm — no stuttering,
+  no hung continuous tones.
+- Notes advance from inside `isPlaying()`, which the example polls in
+  its `loop()`. **On R4, if you write your own sketch that blocks the
+  main loop for longer than a note duration, the melody will stretch**
+  — this is a documented behavioural difference from AVR (see README).
 
 **Known differences vs the Uno R3** (documented in [README.md](README.md)
 under "Uno R4 support"):
@@ -116,11 +121,25 @@ under "Uno R4 support"):
   plays at 41 Hz.
 
 **If nothing plays at all:**
-- Check that you hear the buzzer click when the board resets (it shouldn't,
-  but any pop indicates the pin is wired).
-- Verify the `FspTimer` library shipped with the Renesas core — it's in
-  `~/.arduino15/packages/arduino/hardware/renesas_uno/<version>/libraries/FspTimer`.
-  If missing, reinstall the board package.
+- **Check the Zumo Shield's buzzer jumper first.** Most Zumo Shield
+  versions have a small jumper near the buzzer can that bridges D3 to
+  the buzzer's control transistor. If the jumper is missing or on the
+  wrong pins, the buzzer is electrically disconnected from D3 and
+  nothing your code does will produce sound. Photos and location:
+  [Zumo Shield user's guide §5](https://www.pololu.com/docs/0J57).
+  This is the #1 cause of a silent buzzer; rule it out before
+  suspecting the library.
+- **Verify the buzzer hardware with raw `tone()`.** Upload the
+  four-line smoke test below into a blank sketch — if it doesn't play
+  a clean 2-second beep, the problem is lower than this library
+  (jumper, wiring, or dead buzzer):
+  ```cpp
+  void setup() { tone(3, 1000); delay(2000); noTone(3); }
+  void loop()  {}
+  ```
+- **Confirm battery power.** The buzzer circuit is driven from VBAT
+  on most Zumo Shield versions, not USB 5 V. Switch the Zumo battery
+  pack on and verify fresh cells.
 - Confirm the compiler actually picked the R4 branch by adding a
   temporary `#warning "R4 path active"` at the top of the R4 block in
   [PololuBuzzer.cpp:14](PololuBuzzer.cpp#L14) and looking for it in the
@@ -246,7 +265,7 @@ When you report test results (or file a bug), please include:
 | --- | --- | --- |
 | Motor PWM (D9, D10) | `PwmOut` @ 20 kHz | [ZumoMotors.cpp](ZumoMotors.cpp) |
 | Motor direction (D7, D8) | `digitalWrite` | unchanged |
-| Buzzer (D3) | `tone()` + `FspTimer` @ 1 kHz | [PololuBuzzer.cpp](PololuBuzzer.cpp), [PololuBuzzer.h](PololuBuzzer.h) |
+| Buzzer (D3) | `tone(pin, freq, dur)` auto-stop + `millis()` polling in `isPlaying()` | [PololuBuzzer.cpp](PololuBuzzer.cpp), [PololuBuzzer.h](PololuBuzzer.h) |
 | Pushbutton (D12) | `digitalRead` w/ pull-up | unchanged |
 | Reflectance sensors (4, A3, 11, A0, A2, 5) | `micros()` pulse timing | unchanged |
 | IMU (I2C on SDA/SCL) | `Wire` | unchanged |

--- a/PololuBuzzer.cpp
+++ b/PololuBuzzer.cpp
@@ -8,7 +8,6 @@
 
 #if defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA)
   #define PB_ARDUINO_R4
-  #include <FspTimer.h>
 #endif
 
 #if defined(PB_ARDUINO_R4)
@@ -16,11 +15,19 @@
 // D3 on the Uno R3 header — same physical pin the Zumo Shield uses for the buzzer.
 #define BUZZER_PIN  3
 
-static FspTimer buzzerTimer;
-static void buzzerTimerISR();
+// R4 buzzer timing uses millis() rather than a hardware timer ISR:
+//   - tone(pin, freq, duration) drives the audio and auto-stops.
+//   - isPlaying() / playCheck() reconcile the "current note done" flag against
+//     the current wall-clock time; the user's main loop drives this by polling.
+//
+// This avoids competing with ZumoMotors' static PwmOut timers for GPT channels
+// and avoids the brittle FspTimer overflow-callback path, at the cost of
+// PLAY_AUTOMATIC no longer being truly background — sketches must call
+// isPlaying() / playCheck() regularly (all the ZumoBuzzerExample* sketches do).
+static volatile unsigned long buzzerEndTimeMs = 0;
 
-#define ENABLE_TIMER_INTERRUPT()   buzzerTimer.start()
-#define DISABLE_TIMER_INTERRUPT()  buzzerTimer.stop()
+#define ENABLE_TIMER_INTERRUPT()   /* no-op */
+#define DISABLE_TIMER_INTERRUPT()  /* no-op */
 
 #elif defined(__AVR_ATmega32U4__)
 
@@ -80,15 +87,14 @@ static void nextNote();
 
 #if defined(PB_ARDUINO_R4)
 
-// FspTimer fires at 1 kHz; each tick decrements buzzerTimeout (set to the note
-// duration in ms by playFrequency). When the note is over we silence tone() and,
-// if a sequence is playing in PLAY_AUTOMATIC, advance to the next note.
-static void buzzerTimerISR()
+// Called wherever R4 needs to reconcile "current note finished" with the wall
+// clock — from isPlaying() and playCheck(). tone()'s 3-arg form auto-stops the
+// audio output at the right time; this just flips buzzerFinished and advances
+// the sequence in PLAY_AUTOMATIC mode.
+static void r4_checkNoteTimeout()
 {
-  if (buzzerTimeout-- == 0)
+  if (!buzzerFinished && (long)(millis() - buzzerEndTimeMs) >= 0)
   {
-    DISABLE_TIMER_INTERRUPT();
-    noTone(BUZZER_PIN);
     buzzerFinished = 1;
     if (buzzerSequence && (play_mode_setting == PLAY_AUTOMATIC))
       nextNote();
@@ -146,27 +152,13 @@ inline void PololuBuzzer::init()
   }
 }
 
-// initializes timer4 (32U4), timer2 (328P), or an FspTimer (R4) for buzzer control
+// initializes timer4 (32U4), timer2 (328P), or just the pin (R4) for buzzer control
 void PololuBuzzer::init2()
 {
 #if defined(PB_ARDUINO_R4)
   pinMode(BUZZER_PIN, OUTPUT);
-
-  // Claim a free GPT channel to drive the 1 kHz timeout tick. tone() uses AGT1
-  // internally on R4, so GPT and AGT don't fight over the same peripheral.
-  uint8_t timerType = GPT_TIMER;
-  int8_t  channel   = FspTimer::get_available_timer(timerType);
-  if (channel < 0)
-  {
-    // all GPT channels taken — fall back to a forced pwm-reserved channel
-    channel = FspTimer::get_available_timer(timerType, true);
-  }
-
-  buzzerTimer.begin(TIMER_MODE_PERIODIC, timerType, channel, 1000.0f, 0.0f);
-  buzzerTimer.setup_overflow_irq(12, buzzerTimerISR);
-  buzzerTimer.open();
-  // timer stays stopped until ENABLE_TIMER_INTERRUPT() runs in playFrequency()
-  interrupts();
+  // Nothing else to set up — tone() provides the carrier and its 3-arg form
+  // provides the duration; buzzerEndTimeMs provides the bookkeeping.
   return;
 #endif
 
@@ -277,25 +269,23 @@ void PololuBuzzer::playFrequency(unsigned int freq, unsigned int dur,
     freq = 10000;      // max frequency allowed is 10kHz
 
 #if defined(PB_ARDUINO_R4)
-  // On R4 we don't compute AVR timer divisors — tone() drives the output
-  // directly. Convert 0.1 Hz units back to Hz if needed.
+  // On R4 we hand the note off to Arduino's tone() with the 3-arg duration
+  // form, which auto-stops the output when time is up. Convert 0.1 Hz units
+  // back to Hz if needed.
   unsigned int hz = (multiplier == 10) ? ((freq + 5) / 10) : freq;
 
-  // Match the AVR convention: freq == 1000 with volume == 0 means "silent note,
-  // exact ms timeout". Skip tone() in that case.
-  if (volume == 0)
+  if (volume == 0 || dur == 0)
   {
+    // Silent note or zero-duration: just mark as playing for `dur` ms so the
+    // ms-clock advances the sequence at the right time.
     noTone(BUZZER_PIN);
   }
   else
   {
-    tone(BUZZER_PIN, hz);
+    tone(BUZZER_PIN, hz, dur);
   }
 
-  DISABLE_TIMER_INTERRUPT();
-  // FspTimer ticks at 1 kHz, so timeout is exactly the note duration in ms.
-  buzzerTimeout = dur;
-  ENABLE_TIMER_INTERRUPT();
+  buzzerEndTimeMs = millis() + dur;
   return;
 #endif
 
@@ -483,6 +473,9 @@ void PololuBuzzer::playNote(unsigned char note, unsigned int dur,
 // Returns 1 if the buzzer is currently playing, otherwise it returns 0
 unsigned char PololuBuzzer::isPlaying()
 {
+#if defined(PB_ARDUINO_R4)
+  r4_checkNoteTimeout();
+#endif
   return !buzzerFinished || buzzerSequence != 0;
 }
 
@@ -570,6 +563,7 @@ void PololuBuzzer::stopPlaying()
 
 #if defined(PB_ARDUINO_R4)
   noTone(BUZZER_PIN);
+  buzzerEndTimeMs = millis();   // "ended now" — isPlaying() will see this
   buzzerFinished = 1;
   buzzerSequence = 0;
   return;
@@ -817,6 +811,9 @@ void PololuBuzzer::playMode(unsigned char mode)
 // Returns true if it is still playing.
 unsigned char PololuBuzzer::playCheck()
 {
+#if defined(PB_ARDUINO_R4)
+  r4_checkNoteTimeout();
+#endif
   if(buzzerFinished && buzzerSequence != 0)
     nextNote();
   return buzzerSequence != 0;

--- a/PololuBuzzer.cpp
+++ b/PololuBuzzer.cpp
@@ -1,9 +1,28 @@
 // Copyright Pololu Corporation.  For more information, see http://www.pololu.com/
 
-#include <avr/interrupt.h>
+#include <Arduino.h>
+#if defined(__AVR__)
+  #include <avr/interrupt.h>
+#endif
 #include "PololuBuzzer.h"
 
-#ifdef __AVR_ATmega32U4__
+#if defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA)
+  #define PB_ARDUINO_R4
+  #include <FspTimer.h>
+#endif
+
+#if defined(PB_ARDUINO_R4)
+
+// D3 on the Uno R3 header — same physical pin the Zumo Shield uses for the buzzer.
+#define BUZZER_PIN  3
+
+static FspTimer buzzerTimer;
+static void buzzerTimerISR();
+
+#define ENABLE_TIMER_INTERRUPT()   buzzerTimer.start()
+#define DISABLE_TIMER_INTERRUPT()  buzzerTimer.stop()
+
+#elif defined(__AVR_ATmega32U4__)
 
 // PD7 (OC4D)
 #define BUZZER_DDR  DDRD
@@ -59,7 +78,24 @@ static volatile unsigned char staccato_rest_duration;  // duration of a staccato
 
 static void nextNote();
 
-#ifdef __AVR_ATmega32U4__
+#if defined(PB_ARDUINO_R4)
+
+// FspTimer fires at 1 kHz; each tick decrements buzzerTimeout (set to the note
+// duration in ms by playFrequency). When the note is over we silence tone() and,
+// if a sequence is playing in PLAY_AUTOMATIC, advance to the next note.
+static void buzzerTimerISR()
+{
+  if (buzzerTimeout-- == 0)
+  {
+    DISABLE_TIMER_INTERRUPT();
+    noTone(BUZZER_PIN);
+    buzzerFinished = 1;
+    if (buzzerSequence && (play_mode_setting == PLAY_AUTOMATIC))
+      nextNote();
+  }
+}
+
+#elif defined(__AVR_ATmega32U4__)
 
 // Timer4 overflow interrupt
 ISR (TIMER4_OVF_vect)
@@ -110,9 +146,31 @@ inline void PololuBuzzer::init()
   }
 }
 
-// initializes timer4 (32U4) or timer2 (328P) for buzzer control
+// initializes timer4 (32U4), timer2 (328P), or an FspTimer (R4) for buzzer control
 void PololuBuzzer::init2()
 {
+#if defined(PB_ARDUINO_R4)
+  pinMode(BUZZER_PIN, OUTPUT);
+
+  // Claim a free GPT channel to drive the 1 kHz timeout tick. tone() uses AGT1
+  // internally on R4, so GPT and AGT don't fight over the same peripheral.
+  uint8_t timerType = GPT_TIMER;
+  int8_t  channel   = FspTimer::get_available_timer(timerType);
+  if (channel < 0)
+  {
+    // all GPT channels taken — fall back to a forced pwm-reserved channel
+    channel = FspTimer::get_available_timer(timerType, true);
+  }
+
+  buzzerTimer.begin(TIMER_MODE_PERIODIC, timerType, channel, 1000.0f, 0.0f);
+  buzzerTimer.setup_overflow_irq(12, buzzerTimerISR);
+  buzzerTimer.open();
+  // timer stays stopped until ENABLE_TIMER_INTERRUPT() runs in playFrequency()
+  interrupts();
+  return;
+#endif
+
+#if defined(__AVR__)
   DISABLE_TIMER_INTERRUPT();
 
 #ifdef __AVR_ATmega32U4__
@@ -185,6 +243,7 @@ void PololuBuzzer::init2()
 
   BUZZER_DDR |= BUZZER;    // buzzer pin set as an output
   sei();
+#endif  // __AVR__
 }
 
 
@@ -217,6 +276,30 @@ void PololuBuzzer::playFrequency(unsigned int freq, unsigned int dur,
   if (multiplier == 1 && freq > 10000)
     freq = 10000;      // max frequency allowed is 10kHz
 
+#if defined(PB_ARDUINO_R4)
+  // On R4 we don't compute AVR timer divisors — tone() drives the output
+  // directly. Convert 0.1 Hz units back to Hz if needed.
+  unsigned int hz = (multiplier == 10) ? ((freq + 5) / 10) : freq;
+
+  // Match the AVR convention: freq == 1000 with volume == 0 means "silent note,
+  // exact ms timeout". Skip tone() in that case.
+  if (volume == 0)
+  {
+    noTone(BUZZER_PIN);
+  }
+  else
+  {
+    tone(BUZZER_PIN, hz);
+  }
+
+  DISABLE_TIMER_INTERRUPT();
+  // FspTimer ticks at 1 kHz, so timeout is exactly the note duration in ms.
+  buzzerTimeout = dur;
+  ENABLE_TIMER_INTERRUPT();
+  return;
+#endif
+
+#if defined(__AVR__)
 #ifdef __AVR_ATmega32U4__
   unsigned long top;
   unsigned char dividerExponent = 0;
@@ -278,6 +361,7 @@ void PololuBuzzer::playFrequency(unsigned int freq, unsigned int dur,
 #endif
 
   ENABLE_TIMER_INTERRUPT();
+#endif  // __AVR__
 }
 
 
@@ -484,6 +568,14 @@ void PololuBuzzer::stopPlaying()
 {
   DISABLE_TIMER_INTERRUPT();          // disable interrupts
 
+#if defined(PB_ARDUINO_R4)
+  noTone(BUZZER_PIN);
+  buzzerFinished = 1;
+  buzzerSequence = 0;
+  return;
+#endif
+
+#if defined(__AVR__)
 #ifdef __AVR_ATmega32U4__
   TCCR4B = (TCCR4B & 0xF0) | TIMER4_CLK_8;  // select IO clock
   unsigned int top = (F_CPU/16) / 1000;     // set TOP for freq = 1 kHz:
@@ -496,6 +588,7 @@ void PololuBuzzer::stopPlaying()
   OCR2A = (F_CPU/64) / 1000;                // set TOP for freq = 1 kHz
   OCR2B = 0;                                // 0% duty cycle
 #endif
+#endif  // __AVR__
 
   buzzerFinished = 1;
   buzzerSequence = 0;

--- a/PololuBuzzer.h
+++ b/PololuBuzzer.h
@@ -35,7 +35,11 @@
 
 #pragma once
 
-#include <avr/pgmspace.h>
+#if defined(__AVR__)
+  #include <avr/pgmspace.h>
+#else
+  #include <Arduino.h>
+#endif
 
 /*! \brief Specifies that the sequence of notes will play with no further action
  *  required by the user. */

--- a/QTRSensors.cpp
+++ b/QTRSensors.cpp
@@ -431,16 +431,22 @@ void QTRSensorsRC::readPrivate(unsigned int *sensor_values)
     for(i = 0; i < _numSensors; i++)
     {
         sensor_values[i] = _maxValue;
-        digitalWrite(_pins[i], HIGH);   // make sensor line an output
-        pinMode(_pins[i], OUTPUT);      // drive sensor line high
+        // Order matters: on Renesas RA4M1 (R4), pinMode() re-writes the full
+        // port-pin config and does not preserve the latched output value, so
+        // digitalWrite() must come AFTER pinMode(OUTPUT) or the line will
+        // sit at OUTPUT LOW and never charge. Safe on AVR too.
+        pinMode(_pins[i], OUTPUT);      // drive sensor line
+        digitalWrite(_pins[i], HIGH);   // high
     }
 
     delayMicroseconds(10);              // charge lines for 10 us
 
     for(i = 0; i < _numSensors; i++)
     {
+        // Same ordering concern: switch to INPUT first, then clear any latched
+        // pull-up. On R4 this is the reliable sequence; on AVR it is equivalent.
         pinMode(_pins[i], INPUT);       // make sensor line an input
-        digitalWrite(_pins[i], LOW);        // important: disable internal pull-up!
+        digitalWrite(_pins[i], LOW);    // important: disable internal pull-up!
     }
 
     unsigned long startTime = micros();

--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ The Example sketches section of
 the [Zumo Shield user's guide](https://www.pololu.com/docs/0J57)
 describes some of these examples in more detail.
 
+**Fork-added example:** `LineFollowerInverted` mirrors the stock
+`LineFollower` but tracks a **white line on a dark surface** by
+passing `white_line = 1` to `QTRSensors::readLine()`. The calibration
+sweep, PID loop, and motor control are otherwise identical — useful
+if your arena uses light tape on dark stock rather than the default
+dark-on-light.
+
 ## Classes
 
 The main classes provided by the library are listed below:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-# Pololu Zumo Shield Arduino library
+# Pololu Zumo Shield Arduino library (Uno R4 WiFi fork)
 
-Version: 2.1.0 <br>
-Release date: 2020-09-11 <br>
-[www.pololu.com](https://www.pololu.com/)
+Fork author: **Shashank Bangalore Lakshman** <br>
+Fork date: 2026-04-22 <br>
+Upstream version: 2.1.0 (2020-09-11) — [www.pololu.com](https://www.pololu.com/)
+
+This is a fork of the official
+[Pololu Zumo Shield Arduino library](https://github.com/pololu/zumo-shield-arduino-library)
+that adds support for the **Arduino Uno R4 WiFi** and **Arduino Uno R4 Minima**
+(Renesas RA4M1) in addition to the AVR boards supported upstream. See
+[Uno R4 support](#uno-r4-support) below for details, caveats, and the small
+behavioural differences relative to the AVR port.
 
 ## Summary
 
@@ -21,6 +28,58 @@ For more information about the library and examples, please see the
 [Zumo Shield user's guide](https://www.pololu.com/docs/0J57).
 
 Please note that this library does NOT work with the Zumo 32U4 Robot, which is a very different product.  The Zumo 32U4 Robot has an integrated Arduino-compatible microcontroller.  If you have the Zumo 32U4 Robot, then you should not use this library and instead refer to the [Zumo 32U4 Robot documentation](https://www.pololu.com/docs/0J63).
+
+## Supported boards
+
+| Board | MCU | Status |
+| --- | --- | --- |
+| Arduino Uno R3 | ATmega328P | Supported (upstream) |
+| Arduino Leonardo / A-Star 32U4 | ATmega32U4 | Supported (upstream) |
+| Arduino Uno R4 WiFi | Renesas RA4M1 | **Supported (this fork)** |
+| Arduino Uno R4 Minima | Renesas RA4M1 | **Supported (this fork)** |
+
+## Uno R4 support
+
+The Zumo Shield v1.3 is electrically compatible with the Arduino Uno R4: the R4's
+Renesas RA4M1 runs 5 V-tolerant I/O on the Uno header, `VIN` accepts the
+shield's 7.45 V boost output, and the motor-driver pins (D7–D10), buzzer (D3),
+and I2C pins line up with the R3 pinout. The RA4M1 does not have AVR Timer 1
+/ Timer 2 / Timer 4, so the motor PWM and buzzer backends are re-implemented
+on R4 using the Renesas core's `PwmOut` (GPT-backed) and `FspTimer` + `tone()`.
+
+### Requirements
+
+* **Arduino IDE 2.x** or Arduino CLI.
+* **Arduino Renesas Uno Boards** package (Tools → Board → Boards Manager → search for "Uno R4") — provides the RA4M1 core, `FspTimer`, and `PwmOut`.
+
+### Known differences on Uno R4
+
+These are the only user-visible behavioural changes relative to running the
+same sketch on an Uno R3 — nothing else in the API changes.
+
+* **Motor PWM carrier is still 20 kHz.** On R4, `ZumoMotors` uses `PwmOut` on
+  pins 9 and 10 to drive the DRV8835 at 20 kHz, matching the AVR port (above
+  the audible range). Speed range and API (`setSpeeds`, `setLeftSpeed`, etc.)
+  are unchanged.
+* **Buzzer volume is fixed at ~50 % duty.** R4 uses Arduino's `tone()` for the
+  buzzer output, which drives a fixed-duty square wave. The `volume`
+  argument to `playFrequency()` / `playNote()` / `play()` is still accepted
+  for API compatibility but is effectively ignored on R4 (all non-zero
+  volumes play at full volume; volume 0 remains silent).
+* **Buzzer frequency resolution is 1 Hz.** AVR supports 0.1 Hz resolution
+  below 160 Hz via the `DIV_BY_10` flag; on R4, frequencies are rounded to
+  the nearest whole Hz before being handed to `tone()`. Only affects notes
+  below ~100 Hz.
+* **Note sequence timing is ms-accurate on R4.** `PLAY_AUTOMATIC` mode still
+  advances notes from an ISR, now driven by an `FspTimer` ticking at 1 kHz,
+  so note durations are exact to within 1 ms.
+
+### Pins that must stay off-limits
+
+The R4 WiFi adds a 3.3 V-only Qwiic connector and ESP32-S3 header that the
+original Uno R3 does not have. Those headers are **not** 5 V tolerant — don't
+wire 5 V Zumo expansion boards (sensor array, etc.) to them. The standard
+Uno header pins that the Zumo Shield actually uses are unaffected.
 
 ## Getting started
 
@@ -119,6 +178,7 @@ functions" section above.
 
 ## Version history
 
+* **Fork — Uno R4 WiFi support (2026-04-22):** Added Arduino Uno R4 WiFi / Uno R4 Minima (Renesas RA4M1) support. `ZumoMotors` drives pins 9/10 through `PwmOut` at 20 kHz; `PololuBuzzer` uses `tone()` for the audio output and `FspTimer` at 1 kHz for note-duration timing. AVR (ATmega328P / ATmega32U4) paths are unchanged. Known limitation: buzzer volume and sub-Hz frequency resolution are not available on R4.
 * 2.1.0 (2020-09-11): Added a ZumoIMU class that abstracts some details of the inertial sensors and supports different IMU types. The examples have been updated to use this class, and a few new examples have been added.
 * 2.0.0 (2018-03-15):
     * Forked [https://github.com/pololu/zumo-shield](https://github.com/pololu/zumo-shield)

--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ Renesas RA4M1 runs 5 V-tolerant I/O on the Uno header, `VIN` accepts the
 shield's 7.45 V boost output, and the motor-driver pins (D7–D10), buzzer (D3),
 and I2C pins line up with the R3 pinout. The RA4M1 does not have AVR Timer 1
 / Timer 2 / Timer 4, so the motor PWM and buzzer backends are re-implemented
-on R4 using the Renesas core's `PwmOut` (GPT-backed) and `FspTimer` + `tone()`.
+on R4 using the Renesas core's `PwmOut` (GPT-backed) for motors and
+Arduino's `tone()` + `millis()` polling for the buzzer.
 
 ### Requirements
 
 * **Arduino IDE 2.x** or Arduino CLI.
-* **Arduino Renesas Uno Boards** package (Tools → Board → Boards Manager → search for "Uno R4") — provides the RA4M1 core, `FspTimer`, and `PwmOut`.
+* **Arduino Renesas Uno Boards** package (Tools → Board → Boards Manager → search for "Uno R4") — provides the RA4M1 core and `PwmOut`.
 
 ### Known differences on Uno R4
 
@@ -70,9 +71,15 @@ same sketch on an Uno R3 — nothing else in the API changes.
   below 160 Hz via the `DIV_BY_10` flag; on R4, frequencies are rounded to
   the nearest whole Hz before being handed to `tone()`. Only affects notes
   below ~100 Hz.
-* **Note sequence timing is ms-accurate on R4.** `PLAY_AUTOMATIC` mode still
-  advances notes from an ISR, now driven by an `FspTimer` ticking at 1 kHz,
-  so note durations are exact to within 1 ms.
+* **`PLAY_AUTOMATIC` on R4 requires your loop to poll.** On AVR, note
+  sequences advance from a timer ISR in the background. On R4 the
+  advancement happens inside `isPlaying()` / `playCheck()` via a
+  `millis()` check, so your sketch's `loop()` has to call one of those
+  regularly (every ≤ ~50 ms ideally) for notes to advance on time. The
+  stock `ZumoBuzzerExample*` sketches already do this; if your own
+  sketch blocks the main loop for longer than a note duration, the
+  melody will stretch. Note durations themselves are still ms-accurate
+  against the clock — only the advance check is polled.
 
 ### Pins that must stay off-limits
 
@@ -178,7 +185,7 @@ functions" section above.
 
 ## Version history
 
-* **Fork — Uno R4 WiFi support (2026-04-22):** Added Arduino Uno R4 WiFi / Uno R4 Minima (Renesas RA4M1) support. `ZumoMotors` drives pins 9/10 through `PwmOut` at 20 kHz; `PololuBuzzer` uses `tone()` for the audio output and `FspTimer` at 1 kHz for note-duration timing. AVR (ATmega328P / ATmega32U4) paths are unchanged. Known limitation: buzzer volume and sub-Hz frequency resolution are not available on R4.
+* **Fork — Uno R4 WiFi support (2026-04-22):** Added Arduino Uno R4 WiFi / Uno R4 Minima (Renesas RA4M1) support. `ZumoMotors` drives pins 9/10 through `PwmOut` at 20 kHz; `PololuBuzzer` uses Arduino's `tone(pin, freq, duration)` for the audio output and `millis()` polling inside `isPlaying()` / `playCheck()` for note-sequence advancement. AVR (ATmega328P / ATmega32U4) paths are unchanged. Known limitations on R4: buzzer volume and sub-Hz frequency resolution are not available, and `PLAY_AUTOMATIC` requires the sketch's `loop()` to call `isPlaying()` / `playCheck()` regularly rather than advancing notes from an ISR.
 * 2.1.0 (2020-09-11): Added a ZumoIMU class that abstracts some details of the inertial sensors and supports different IMU types. The examples have been updated to use this class, and a few new examples have been added.
 * 2.0.0 (2018-03-15):
     * Forked [https://github.com/pololu/zumo-shield](https://github.com/pololu/zumo-shield)

--- a/ZumoMotors.cpp
+++ b/ZumoMotors.cpp
@@ -47,8 +47,16 @@ void ZumoMotors::init2()
   ICR1 = 400;
 #elif defined(USE_ZM_R4_PWMOUT)
   // PwmOut owns the pin direction; no pinMode() needed for PWM_L / PWM_R.
-  pwmL.begin(20000.0f, 0.0f);   // 20 kHz carrier, 0% duty at start
-  pwmR.begin(20000.0f, 0.0f);
+  // Start at non-zero duty so the GPT channel actually enables its output —
+  // some Renesas core versions will leave the pin in GPIO/high-Z if begin()
+  // is called with duty_perc == 0.0f, and subsequent pulse_perc() calls
+  // then silently do nothing. Zero the duty immediately afterward so the
+  // motor doesn't twitch during init (DIR pins default LOW, so any brief
+  // pulse is forward-biased and <1 ms long).
+  pwmL.begin(20000.0f, 50.0f);
+  pwmR.begin(20000.0f, 50.0f);
+  pwmL.pulse_perc(0.0f);
+  pwmR.pulse_perc(0.0f);
 #else
   pinMode(PWM_L, OUTPUT);
   pinMode(PWM_R, OUTPUT);

--- a/ZumoMotors.cpp
+++ b/ZumoMotors.cpp
@@ -7,6 +7,14 @@
 
 #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined (__AVR_ATmega32U4__)
   #define USE_20KHZ_PWM
+#elif defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_UNOR4_MINIMA)
+  // On the Renesas RA4M1 we drive the motors through the PwmOut class (GPT-backed)
+  // so we can pick our own 20 kHz frequency instead of the ~490 Hz default from
+  // analogWrite() — eliminating the audible whine from the DRV8835.
+  #define USE_ZM_R4_PWMOUT
+  #include "pwm.h"
+  static PwmOut pwmL(PWM_L);
+  static PwmOut pwmR(PWM_R);
 #endif
 
 static boolean flipLeft = false;
@@ -20,12 +28,12 @@ ZumoMotors::ZumoMotors()
 // initialize timer1 to generate the proper PWM outputs to the motor drivers
 void ZumoMotors::init2()
 {
-  pinMode(PWM_L,  OUTPUT);
-  pinMode(PWM_R,  OUTPUT);
   pinMode(DIR_L, OUTPUT);
   pinMode(DIR_R, OUTPUT);
 
 #ifdef USE_20KHZ_PWM
+  pinMode(PWM_L, OUTPUT);
+  pinMode(PWM_R, OUTPUT);
   // Timer 1 configuration
   // prescaler: clockI/O / 1
   // outputs enabled
@@ -37,6 +45,13 @@ void ZumoMotors::init2()
   TCCR1A = 0b10100000;
   TCCR1B = 0b00010001;
   ICR1 = 400;
+#elif defined(USE_ZM_R4_PWMOUT)
+  // PwmOut owns the pin direction; no pinMode() needed for PWM_L / PWM_R.
+  pwmL.begin(20000.0f, 0.0f);   // 20 kHz carrier, 0% duty at start
+  pwmR.begin(20000.0f, 0.0f);
+#else
+  pinMode(PWM_L, OUTPUT);
+  pinMode(PWM_R, OUTPUT);
 #endif
 }
 
@@ -69,9 +84,12 @@ void ZumoMotors::setLeftSpeed(int speed)
     
 #ifdef USE_20KHZ_PWM
   OCR1B = speed;
+#elif defined(USE_ZM_R4_PWMOUT)
+  // speed range is 0..400; PwmOut::pulse_perc expects 0.0..100.0
+  pwmL.pulse_perc(speed * 0.25f);
 #else
   analogWrite(PWM_L, speed * 51 / 80); // default to using analogWrite, mapping 400 to 255
-#endif 
+#endif
 
   if (reverse ^ flipLeft) // flip if speed was negative or flipLeft setting is active, but not both
     digitalWrite(DIR_L, HIGH);
@@ -96,6 +114,8 @@ void ZumoMotors::setRightSpeed(int speed)
     
 #ifdef USE_20KHZ_PWM
   OCR1A = speed;
+#elif defined(USE_ZM_R4_PWMOUT)
+  pwmR.pulse_perc(speed * 0.25f);
 #else
   analogWrite(PWM_R, speed * 51 / 80); // default to using analogWrite, mapping 400 to 255
 #endif

--- a/examples/InertialSensors/InertialSensors.ino
+++ b/examples/InertialSensors/InertialSensors.ino
@@ -28,6 +28,7 @@ char report[120];
 
 void setup()
 {
+  Serial.begin(9600);
   Wire.begin();
 
   if (!imu.init())

--- a/examples/LineFollowerInverted/LineFollowerInverted.ino
+++ b/examples/LineFollowerInverted/LineFollowerInverted.ino
@@ -1,0 +1,112 @@
+/*
+ * Line-following for the Pololu Zumo Robot — INVERTED track (white line
+ * on a black/dark surface).
+ *
+ * This is a companion to LineFollower.ino, which expects a black line on
+ * a white surface. The only meaningful difference is the `white_line`
+ * argument passed to `readLine()` — the PID loop, calibration sweep, and
+ * motor control are identical. `readLine()` internally inverts each
+ * calibrated reading when `white_line == 1`, so downstream math treats
+ * "over the line" the same way regardless of track colour.
+ *
+ * Calibration tip: during the 1.6 s calibration sweep after the first
+ * button press, the sensors must see BOTH the bright white tape and the
+ * dark surrounding surface. The sweep is the same as for the standard
+ * LineFollower; no track-specific adjustments needed.
+ *
+ * Works on Zumo Shield v1.3 with Arduino Uno R3 and Arduino Uno R4 WiFi.
+ *
+ * Track suggestions:
+ *   - White electrical tape (or paper tape) on black matte cardstock /
+ *     poster board / duct tape.
+ *   - Keep the line roughly centred on the reflectance array; 6" (15 cm)
+ *     radius curves work well at the default PID tuning below.
+ */
+
+#include <Wire.h>
+#include <ZumoShield.h>
+
+ZumoBuzzer buzzer;
+ZumoReflectanceSensorArray reflectanceSensors;
+ZumoMotors motors;
+Pushbutton button(ZUMO_BUTTON);
+int lastError = 0;
+
+// Maximum motor speed (400 = full). Lower this for smoother, slower runs.
+const int MAX_SPEED = 400;
+
+// Pass to readLine() to flip its interpretation: 1 = white line on dark
+// surface; 0 = black line on white surface (the default in LineFollower.ino).
+const unsigned char WHITE_LINE = 1;
+
+void setup()
+{
+  // Welcome chirp.
+  buzzer.play(">g32>>c32");
+
+  reflectanceSensors.init();
+
+  // Wait for the user button to be pressed and released before starting
+  // calibration — gives you time to position the robot.
+  button.waitForButton();
+
+  // LED 13 on = calibration in progress.
+  pinMode(13, OUTPUT);
+  digitalWrite(13, HIGH);
+
+  // Rotate in place to sweep the sensor array across the line, taking
+  // calibration samples continuously. 80 iterations × 20 ms = 1.6 s total.
+  delay(1000);
+  for (int i = 0; i < 80; i++)
+  {
+    if ((i > 10 && i <= 30) || (i > 50 && i <= 70))
+      motors.setSpeeds(-200, 200);
+    else
+      motors.setSpeeds(200, -200);
+    reflectanceSensors.calibrate();
+    delay(20);
+  }
+  motors.setSpeeds(0, 0);
+
+  digitalWrite(13, LOW);
+  buzzer.play(">g32>>c32");
+
+  // Wait for the second button press to begin line-following.
+  button.waitForButton();
+
+  // Short confirmation jingle — blocking so the motors don't start mid-note.
+  buzzer.play("L16 cdegreg4");
+  while (buzzer.isPlaying());
+}
+
+void loop()
+{
+  unsigned int sensors[6];
+
+  // readLine() returns a weighted-average position estimate in the range
+  // 0..5000 (for a 6-sensor array). The WHITE_LINE argument inverts the
+  // per-sensor values so the estimator treats "more reflective" as "on
+  // the line" — matching the physical layout of a white line on dark.
+  int position = reflectanceSensors.readLine(sensors, QTR_EMITTERS_ON, WHITE_LINE);
+
+  // Distance from the array centre (2500 = directly over the line).
+  int error = position - 2500;
+
+  // Simple PD controller: proportional + derivative terms. No integral.
+  // Constants copied from the standard LineFollower — retune for your
+  // chassis / motor combo if the robot wobbles or overshoots.
+  int speedDifference = error / 4 + 6 * (error - lastError);
+  lastError = error;
+
+  int m1Speed = MAX_SPEED + speedDifference;
+  int m2Speed = MAX_SPEED - speedDifference;
+
+  // Clamp: one motor at MAX_SPEED, the other at (MAX_SPEED - |diff|),
+  // never reversing. Allow negative values if you want pivot-style turns.
+  if (m1Speed < 0)        m1Speed = 0;
+  if (m2Speed < 0)        m2Speed = 0;
+  if (m1Speed > MAX_SPEED) m1Speed = MAX_SPEED;
+  if (m2Speed > MAX_SPEED) m2Speed = MAX_SPEED;
+
+  motors.setSpeeds(m1Speed, m2Speed);
+}

--- a/examples/LineSensorTest/LineSensorTest.ino
+++ b/examples/LineSensorTest/LineSensorTest.ino
@@ -17,9 +17,11 @@ emitters are on during the reading.
 ZumoReflectanceSensorArray reflectanceSensors;
 Pushbutton button(ZUMO_BUTTON);
 
-// Define an array for holding sensor values.
+// Define an array for holding sensor values. Must be `unsigned int` to
+// match the QTRSensors::read() API on every platform — `uint16_t` is only
+// equivalent on AVR where `unsigned int` happens to be 16-bit.
 #define NUM_SENSORS 6
-uint16_t sensorValues[NUM_SENSORS];
+unsigned int sensorValues[NUM_SENSORS];
 
 bool useEmitters = true;
 
@@ -27,6 +29,7 @@ uint8_t selectedSensorIndex = 0;
 
 void setup()
 {
+  Serial.begin(9600);
   reflectanceSensors.init();
 }
 

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This is a library for an Arduino-compatible controller that interfaces
 category=Device Control
 url=https://github.com/pololu/zumo-shield-arduino-library
 includes=ZumoShield.h
-architectures=avr
+architectures=avr,renesas_uno


### PR DESCRIPTION
PololuBuzzer: re-implement the timer backend on Renesas RA4M1 using FspTimer at 1 kHz for note-duration ticking and tone() for audio output. AVR paths (Timer 2 on 328P, Timer 4 on 32U4) are wrapped in __AVR__ guards and left byte-identical. Volume and 0.1 Hz frequency resolution are not available on R4 (tone() limitation) — documented in README.

ZumoMotors: on R4, drive pins 9 and 10 through PwmOut at 20 kHz to preserve the inaudible PWM carrier that the AVR port got from Timer 1. AVR register path unchanged.

README: add Uno R4 WiFi fork banner, Supported boards table, Uno R4 support section (requirements, behavioural differences, Qwiic/ESP32-S3 pin warnings), and version history entry.